### PR TITLE
ClientInterface::request did not accept null

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -44,9 +44,9 @@ interface ClientInterface
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string              $method  HTTP method
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string                   $method  HTTP method
+     * @param string|UriInterface|null $uri     URI object or string.
+     * @param array                    $options Request options to apply.
      *
      * @return ResponseInterface
      * @throws GuzzleException

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -51,7 +51,7 @@ interface ClientInterface
      * @return ResponseInterface
      * @throws GuzzleException
      */
-    public function request($method, $uri, array $options = []);
+    public function request($method, $uri = null, array $options = []);
 
     /**
      * Create and send an asynchronous HTTP request.


### PR DESCRIPTION
I found a difference between the ClientInterface and the Client Implementation Request Method.
The `$uri` is required in the Interface, however in the Implementation it is allowed to be null.
See:
https://github.com/guzzle/guzzle/blob/c6851d6e48f63b69357cbfa55bca116448140e0c/src/Client.php#L126 and https://github.com/guzzle/guzzle/blob/c6851d6e48f63b69357cbfa55bca116448140e0c/src/ClientInterface.php#L54

To fix this difference, i changed the `$uri` Parameter in the Interface to default Value `null`
